### PR TITLE
Send master server heartbeat immediately after server startup

### DIFF
--- a/src/rehlmaster.cpp
+++ b/src/rehlmaster.cpp
@@ -65,10 +65,12 @@ void SV_Frame_hook(IRehldsHook_SV_Frame* chain) {
 
 	double dCurTime = g_RehldsFuncs->GetRealTime();
 	static double s_dLastHeartbeat;
+	static bool s_bInitialHeartbeat = true;
 
-	if (dCurTime - s_dLastHeartbeat > HEARTBEAT_TIME)
+	if ((dCurTime - s_dLastHeartbeat > HEARTBEAT_TIME) || s_bInitialHeartbeat)
 	{
 		s_dLastHeartbeat = dCurTime;
+		s_bInitialHeartbeat = false;
 
 		for (int i = 0; i < 5; i++) {
 			if (!pcv_sv_master[i]->string[0]) continue;

--- a/src/rehlmaster.cpp
+++ b/src/rehlmaster.cpp
@@ -86,7 +86,13 @@ void SV_Frame_hook(IRehldsHook_SV_Frame* chain) {
 			netAdr.type = NA_IP;
 
 			g_RehldsFuncs->NET_SendPacket(1, (void*)"q", netAdr);
-			ALERT(at_console, "[rehlmaster] sent master heartbeat to (%d) (%hhu.%hhu.%hhu.%hhu:%hu)\n", (i+1), ((unsigned char *)&ip)[0], ((unsigned char *)&ip)[1], ((unsigned char *)&ip)[2], ((unsigned char *)&ip)[3], PORT_MASTER);
+			ALERT(at_console, "[rehlmaster] sent master heartbeat to (%d) (%hhu.%hhu.%hhu.%hhu:%hu)\n",
+				(i + 1),
+				((unsigned char*)&ip)[0],
+				((unsigned char*)&ip)[1],
+				((unsigned char*)&ip)[2],
+				((unsigned char*)&ip)[3],
+				PORT_MASTER);
 		}
 	}
 }


### PR DESCRIPTION
Send an initial heartbeat to the master server immediately after the server starts up, rather than waiting for the first interval-based check.